### PR TITLE
Fixed player counting

### DIFF
--- a/src/main/java/net/lucasdow/wildernessmod/commands/PlayerCount.java
+++ b/src/main/java/net/lucasdow/wildernessmod/commands/PlayerCount.java
@@ -131,7 +131,7 @@ public class PlayerCount implements Command{
                     .executes(context -> {
                         WildernessMod.LOGGER.info("Setting player count!");
 
-                        int playerCount = context.getSource().getWorld().getPlayers().toArray().length;
+                        int playerCount = context.getSource().getServer().getCurrentPlayerCount();
                         setPlayerCount(context.getSource().getServer().getDataCommandStorage(), playerCount);
                         context.getSource().getPlayer().sendMessage(new LiteralText("Player count set: " + playerCount + ", tier: " + getTier(playerCount)), false);
 

--- a/src/main/java/net/lucasdow/wildernessmod/commands/SpawnChestCommand.java
+++ b/src/main/java/net/lucasdow/wildernessmod/commands/SpawnChestCommand.java
@@ -28,7 +28,7 @@ public class SpawnChestCommand implements Command {
                     .requires(source -> source.hasPermissionLevel(4))
                     .executes(context -> {
                         String lootType = StringArgumentType.getString(context, "loot_type");
-                        int playerCount = context.getSource().getWorld().getPlayers().toArray().length;
+                        int playerCount = context.getSource().getServer().getCurrentPlayerCount();
                         PlayerCount.setPlayerCount(context.getSource().getServer().getDataCommandStorage(), playerCount);
 
                         switch (lootType) {


### PR DESCRIPTION
Confusingly enough a "world" in the Minecraft source is just one dimension, not the whole world, so the mod was counting just the players in the overworld dimension.